### PR TITLE
change default split matcher to `require('os').EOL`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function split (matcher, mapper) {
   if('function' === typeof matcher)
     mapper = matcher, matcher = null
   if (!matcher)
-    matcher = '\n'
+    matcher = /\r?\n/
 
   return through(function (buffer) { 
     var stream = this

--- a/readme.markdown
+++ b/readme.markdown
@@ -15,6 +15,6 @@ Example, read every line in a file ...
 
 ```
 
-`split` takes the same arguments as `string.split` except it defaults to '\n' instead of ',', and the optional `limit` paremeter is ignored.
+`split` takes the same arguments as `string.split` except it defaults to '/\r?\n/' instead of ',', and the optional `limit` paremeter is ignored.
 [String#split](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/split)
 


### PR DESCRIPTION
I'm not sure whether this should be changed or not, but I want to take it up to discussion.
