### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "split",
   "version": "0.3.0",
+  "license": "MIT",
   "description": "split a Text Stream into a Line Stream",
   "homepage": "http://github.com/dominictarr/split",
   "repository": {


### PR DESCRIPTION
Allows license to be read programatically.
