### PR TITLE
Fix splitting empty string chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ function split (matcher, mapper, options) {
       stream.queue(piece)
   }
 
-  function next (stream, buffer) { 
-    var pieces = (soFar + buffer).split(matcher)
+  function next (stream, buffer) {
+    var pieces = ((soFar != null ? soFar : '') + buffer).split(matcher)
     soFar = pieces.pop()
 
     if (maxLength && soFar.length > maxLength)
@@ -53,7 +53,7 @@ function split (matcher, mapper, options) {
     next(this, decoder.write(b))
   },
   function () {
-    if(decoder.end) 
+    if(decoder.end)
       next(this, decoder.end())
     if(soFar != null)
       emit(this, soFar)

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "asynct": "*",
+    "event-stream": "~3.0.2",
     "it-is": "1",
-    "ubelt": "~2.9",
     "stream-spec": "~0.2",
-    "event-stream": "~3.0.2"
+    "ubelt": "~2.9"
   },
   "scripts": {
     "test": "asynct test/"

--- a/test/split.asynct.js
+++ b/test/split.asynct.js
@@ -5,7 +5,10 @@ var es = require('event-stream')
   , join = require('path').join
   , fs = require('fs')
   , Stream = require('stream').Stream
+  , Readable = require('stream').Readable
   , spec = require('stream-spec')
+  , through = require('through')
+  , stringStream = require('string-to-stream')
 
 exports ['split() works like String#split'] = function (test) {
   var readme = join(__filename)
@@ -16,7 +19,7 @@ exports ['split() works like String#split'] = function (test) {
     , x = spec(cs).through()
 
   var a = new Stream ()
-  
+
   a.write = function (l) {
     actual.push(l.trim())
   }
@@ -39,10 +42,10 @@ exports ['split() works like String#split'] = function (test) {
       })
   }
   a.writable = true
-  
+
   fs.createReadStream(readme, {flags: 'r'}).pipe(cs)
-  cs.pipe(a) 
-  
+  cs.pipe(a)
+
 }
 
 exports ['split() takes mapper function'] = function (test) {
@@ -54,7 +57,7 @@ exports ['split() takes mapper function'] = function (test) {
     , x = spec(cs).through()
 
   var a = new Stream ()
-  
+
   a.write = function (l) {
     actual.push(l.trim())
   }
@@ -77,9 +80,58 @@ exports ['split() takes mapper function'] = function (test) {
       })
   }
   a.writable = true
-  
+
   fs.createReadStream(readme, {flags: 'r'}).pipe(cs)
-  cs.pipe(a) 
-  
+  cs.pipe(a)
+
 }
 
+exports ['split() works with empty string chunks'] = function (test) {
+  var str = ' foo'
+    , expected = str.split(/[\s]*/).reduce(splitBy(/[\s]*/), [])
+    , cs1 = split(/[\s]*/)
+    , cs2 = split(/[\s]*/)
+    , actual = []
+    , ended = false
+    , x = spec(cs1).through()
+    , y = spec(cs2).through()
+
+  var a = new Stream ()
+
+  a.write = function (l) {
+    actual.push(l.trim())
+  }
+  a.end = function () {
+
+      ended = true
+      expected.forEach(function (v,k) {
+        //String.split will append an empty string ''
+        //if the string ends in a split pattern.
+        //es.split doesn't which was breaking this test.
+        //clearly, appending the empty string is correct.
+        //tests are passing though. which is the current job.
+        if(v)
+          it(actual[k]).like(v)
+      })
+      //give the stream time to close
+      process.nextTick(function () {
+        test.done()
+        x.validate()
+        y.validate()
+      })
+  }
+  a.writable = true
+
+  cs1.pipe(cs2)
+  cs2.pipe(a)
+
+  cs1.write(str)
+  cs1.end()
+
+}
+
+function splitBy (delimeter) {
+  return function (arr, piece) {
+    return arr.concat(piece.split(delimeter))
+  }
+}


### PR DESCRIPTION
I noticed when using `es.replace` to remove whitespace using multiple RegExps, that if a split resulted in empty string chunks 'undefined' was being inserted into the stream.
I will PR a test case and split-version-bump in event-stream for `es.replace` shortly.